### PR TITLE
Install fixes and readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/ph54iicf29ipy8wm?svg=true)](https://ci.appveyor.com/project/WilixLead/iohook)
+[![Build Status](https://travis-ci.org/WilixLead/iohook.svg?branch=master)](https://travis-ci.org/WilixLead/iohook)
 
 # iohook
 Node.js global native keyboard and mouse listener.  
@@ -40,6 +41,24 @@ Just add following to your package.json file
 }
 ```
 **NOTE: Please remember, when you install iohook, it try to use current node environment NOT ELECTRON OR NW.js**
+
+### Prebuild support  
+iohook support prebuilded binaries for next environment versions:  
+- electron:
+  - [47] 1.0.2
+  - [48] 1.2.8
+  - [49] 1.3.13
+  - [50] 1.4.15
+  - [51] 1.5.0
+  - [53] 1.6.0
+
+- node: 
+  - [46] 4.6.1
+  - [47] 5.12.0
+  - [48] 6.9.4
+  - [51] 7.4.0
+
+Support for node.js v0.12, io.js, nw.js is planed.
 
 ## Manual compilation for your version of environment  
 iohook have prebuild binaries, it downloads when you try to install it.  

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Node.js global native keyboard and mouse listener.  
 This module can handle keyboard and mouse events via native hooks.  
 
-If you like this module or interesting for updates, follow me in Twiller [https://twitter.com/wilixlead](https://twitter.com/wilixlead)
+If you like this module or are interested in updates, follow me on Twitter [https://twitter.com/wilixlead](https://twitter.com/wilixlead)
 
 ## OS Support
 Already tested in:
@@ -20,8 +20,8 @@ I really hope find way for use build systems for online build or download prebui
 `npm install iohook --save`
 
 ### Electron users [optional]
-Before install this module, you need specify build runtime. 
-Just add following to your package.json file 
+Before install this module, you need specify build runtime.
+Just add following to your package.json file
 (if you use two-package-json structure, add to app's package.json, not to build).  
 ```json
 "iohook": {
@@ -30,13 +30,13 @@ Just add following to your package.json file
     "electron-v53"
   ],
   "platforms": [
-    'win32', 
-    'darwin',
-    'linux'
+    "win32",
+    "darwin",
+    "linux"
   ],
   "arches": [
-    'x64', 
-    'ia32'
+    "x64",
+    "ia32"
   ]
 }
 ```
@@ -52,7 +52,7 @@ iohook support prebuilded binaries for next environment versions:
   - [51] 1.5.0
   - [53] 1.6.0
 
-- node: 
+- node:
   - [46] 4.6.1
   - [47] 5.12.0
   - [48] 6.9.4
@@ -64,7 +64,7 @@ Support for node.js v0.12, io.js, nw.js is planed.
 iohook have prebuild binaries, it downloads when you try to install it.  
 But if you use specified version of node.js/nw.js/io.js/electron/etc. you can try compile it.  
 All what you need install os dependencies and start compilation:
-  
+
 ### Ubuntu 16
 - `sudo apt install libx11-dev libxtst-dev libxt-dev libx11-xcb-dev`
 - `sudo apt install libxkbcommon-dev libxkbcommon-x11-dev`
@@ -144,7 +144,6 @@ module crash with "Segmentation fault: 11". Looks like it is problem in my nativ
 but I still can't find a problem. Will be happy if somebody helps with it.
 
 ## Credits
-Thanks for libuiohook project!    
+Thanks for [libuiohook](https://github.com/kwhat/libuiohook) project!    
 Thank you [ayoubserti](https://github.com/ayoubserti) for first iohook prototype  
-Thank you @vespakoen for prebuild system implementation
-
+Thank you [vespakoen](https://github.com/vespakoen) for prebuild system implementation

--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 'use strict';
 const os = require('os');
 const EventEmitter = require('events');
+const path = require('path');
 
-let runtime = process.versions['electron'] ? 'electron' : 'node';
-let essential = runtime + '-v' + process.versions.modules + '-' + process.platform + '-' + process.arch;
-console.log('Loading native binary: ./builds/' + essential + '/build/Release/iohook.node');
-let NodeHookAddon = require('./builds/' + essential + '/build/Release/iohook.node');
+const runtime = process.versions['electron'] ? 'electron' : 'node';
+const essential = runtime + '-v' + process.versions.modules + '-' + process.platform + '-' + process.arch;
+const modulePath = path.join(__dirname, 'builds', essential, 'build', 'Release', 'iohook.node');
+console.log('Loading native binary:', modulePath);
+let NodeHookAddon = require(modulePath);
 
 // Try to remove this handler. I hope...
 // const SegfaultHandler = require('segfault-handler');

--- a/install.js
+++ b/install.js
@@ -87,12 +87,10 @@ function optionsFromPackage(attempts) {
     throw new Error('Can\'t resolve main package.json file');
   }
   let mainPath = Array(attempts).join("../");
-  console.log(mainPath);
   try {
     const content = fs.readFileSync(path.join(__dirname, mainPath, 'package.json'), 'utf-8');
     const packageJson = JSON.parse(content);
-
-    console.log(packageJson);
+    
     return packageJson.iohook || {
         targets: [],
         platforms: [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iohook",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Node.js global keyboard and mouse hook",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Another try at it, not tested yet.
Will ensure to always have arrays, so the length check is safe now.
Also do more options handling before going into the if / else.
Uses defaults for platform & arch when using package options, so something like this should work now:

```json
"iohook": {
  "targets": ["node-7.4.0"]
}
```

I noticed the readme instructs to use something like:

```json
"iohook": {
  "targets": [
    "node-v51"
    "electron-v53"
  ]
}
```

Which is incorrect, the v51, v53 should be the actual version number, instead of the ABI, not sure what you want to do here, using the ABI or version number, the current code situation is getting the ABI from the support.js file (based on the version) so either install.js or the readme have to change.