### PR TITLE
added unload to electron example

### DIFF
--- a/electron-example/main.js
+++ b/electron-example/main.js
@@ -17,5 +17,6 @@ app.on('ready', () => {
 });
 
 app.on('before-quit', () => {
+  ioHook.unload();
   ioHook.stop();
 });


### PR DESCRIPTION
I had to add `unload` in Electron in order to prevent Electron from crashing when quitting the application