### PR TITLE
Ignore arch 'ia32' for 'linux' platform

### DIFF
--- a/install.js
+++ b/install.js
@@ -132,7 +132,7 @@ if (options.targets.length > 0) {
     let abi = parts[1];
     options.platforms.forEach(function(platform) {
       options.arches.forEach(function(arch) {
-        if (platform === 'darwin' && arch === 'ia32') {
+        if ((platform === 'darwin' || platform === 'linux') && arch === 'ia32') {
           return;
         }
         chain = chain.then(function() {


### PR DESCRIPTION
Extends the condition for the 'darwin' platform.