### PR TITLE
Resolves a character on 'Keypress'

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
   - npm -g i npm@latest
   - npm i --ignore-scripts
   - for /f %%i in ('node -v') do set exact_nodejs_version=%%i 
-  - npm run build
+#  - npm run build
   - npm run deploy
 
 #on_success:

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-'use strict';
 const EventEmitter = require('events');
 const path = require('path');
 

--- a/install.js
+++ b/install.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const path = require('path');
 const fs = require('fs');
 const os = require('os');

--- a/src/iohook.cc
+++ b/src/iohook.cc
@@ -421,9 +421,14 @@ v8::Local<v8::Object> fillEventObject(uiohook_event event) {
   if ((event.type >= EVENT_KEY_TYPED) && (event.type <= EVENT_KEY_RELEASED)) {
     v8::Local<v8::Object> keyboard = Nan::New<v8::Object>();
     if (event.type == EVENT_KEY_TYPED) {
-      keyboard->Set(Nan::New("keychar").ToLocalChecked(), Nan::New((uint16_t)event.data.keyboard.keychar));
+      char* character = (char*) &event.data.keyboard.keychar;
+    
+      keyboard->Set(Nan::New("keychar").ToLocalChecked(), Nan::New(character).ToLocalChecked());
+      keyboard->Set(Nan::New("keycode").ToLocalChecked(), Nan::New((uint16_t)event.data.keyboard.rawcode));
+    } else {
+      keyboard->Set(Nan::New("keycode").ToLocalChecked(), Nan::New((uint16_t)event.data.keyboard.keycode));
     }
-    keyboard->Set(Nan::New("keycode").ToLocalChecked(), Nan::New((uint16_t)event.data.keyboard.keycode));
+
     keyboard->Set(Nan::New("rawcode").ToLocalChecked(), Nan::New((uint16_t)event.data.keyboard.rawcode));
 
     obj->Set(Nan::New("keyboard").ToLocalChecked(), keyboard);


### PR DESCRIPTION
## Description
- When the 'keypress' event is called it will convert the 'keychar' to a character.
- Removed 'use strict'
- Removed 'npm run build' from appveyor because the deploy command already does this.
 
## Motivation and Context
Saves users having to resolve this in the JS

## Screenshots (if appropriate):
![keychar](https://user-images.githubusercontent.com/450704/38589701-7b485264-3ce1-11e8-83f3-216856de623f.PNG)

## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
