### PR TITLE
Created property 'shiftKey' on the event object

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const modulePath = path.join(__dirname, 'builds', essential, 'build', 'Release',
 if (process.env.DEBUG) {
   console.info('Loading native binary:', modulePath);
 }
-let NodeHookAddon = require('./build/Release/iohook.node');
+let NodeHookAddon = require(modulePath);
 
 const events = {
   3: 'keypress',

--- a/src/iohook.cc
+++ b/src/iohook.cc
@@ -420,9 +420,17 @@ v8::Local<v8::Object> fillEventObject(uiohook_event event) {
 
   if ((event.type >= EVENT_KEY_TYPED) && (event.type <= EVENT_KEY_RELEASED)) {
     v8::Local<v8::Object> keyboard = Nan::New<v8::Object>();
-    if (event.type == EVENT_KEY_TYPED) {
+    
+    if (event.data.keyboard.keycode == VC_SHIFT_L || event.data.keyboard.keycode == VC_SHIFT_R) {
+      keyboard->Set(Nan::New("shiftKey").ToLocalChecked(), Nan::New(true));
+    } else {
+      keyboard->Set(Nan::New("shiftKey").ToLocalChecked(), Nan::New(false));
+    }
+
+    if (event.type == EVENT_KEY_TYPED) {    
       keyboard->Set(Nan::New("keychar").ToLocalChecked(), Nan::New((uint16_t)event.data.keyboard.keychar));
     }
+
     keyboard->Set(Nan::New("keycode").ToLocalChecked(), Nan::New((uint16_t)event.data.keyboard.keycode));
     keyboard->Set(Nan::New("rawcode").ToLocalChecked(), Nan::New((uint16_t)event.data.keyboard.rawcode));
 


### PR DESCRIPTION
## Description
Created property 'shiftKey' on the event object indicating if the shift key is currently pressed.

## Motivation and Context
Help determine if a keypress has any modifiers. This will need to be repeated for ctrl and meta keys.

## Screenshots (if appropriate):
![shiftkey example](https://user-images.githubusercontent.com/450704/38595071-73b73070-3cfe-11e8-895e-c64867221561.PNG)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
