### PR TITLE
Add ability to listen for when a keyboard shortcut has been released

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -136,13 +136,23 @@ You can register global shortcuts.
 When a shortcut is caught, keyup/keydown events still emit events. It means, that if you register a keyup AND shortcut for `ALT+T`, both events will be emited.
 :::
 
-### registerShortcut(keys, callback)
+### registerShortcut(keys, callback, releaseCallback?)
 
-In next example we register CTRL+F7 shortcut (in MacOS, for other OS, keycodes can be some different).
+In the next example we register CTRL+F7 shortcut (in MacOS. For other OSes, the keycodes could be different).
 
 ```js
 const id = ioHook.registerShortcut([29, 65], (keys) => {
   console.log('Shortcut called with keys:', keys)
+});
+```
+
+We can also specify a callback to run when our shortcut has been released by specifying a third function argument.
+
+```js
+const id = ioHook.registerShortcut([29, 65], (keys) => {
+  console.log('Shortcut called with keys:', keys)
+}, (keys) => {
+  console.log('Shortcut has been released!')
 });
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,10 +47,11 @@ declare class IOHook extends EventEmitter {
   /**
    * Register global shortcut. When all keys in keys array pressed, callback will be called
    * @param {Array<string|number>} keys Array of keycodes
-   * @param {Function} callback Callback for call when shortcut pressed
+   * @param {Function} callback Callback for when shortcut pressed
+   * @param {Function} [releaseCallback] Callback for when shortcut released
    * @return {number} ShortcutId for unregister
    */
-  registerShortcut(keys: Array<string|number>, callback: Function): number
+  registerShortcut(keys: Array<string|number>, callback: Function, releaseCallback?: Function): number
 
   /**
    * Unregister shortcut by ShortcutId

--- a/test/specs/keyboard.spec.js
+++ b/test/specs/keyboard.spec.js
@@ -178,4 +178,22 @@ describe('Keyboard events', () => {
       robot.keyToggle('command', 'up');
     }, 50);
   });
+
+  it('runs a callback when a shortcut has been released', (done) => {
+    expect.assertions(2);
+
+    let shortcut = [42, 30];
+
+    ioHook.registerShortcut(shortcut, keys => {
+      expect(shortcut.sort()).toEqual(keys.sort());
+    }, keys => {
+      expect(shortcut.sort()).toEqual(keys.sort());
+    });
+
+    setTimeout(() => { // Make sure ioHook starts before anything gets typed
+      robot.keyToggle('shift', 'down');
+      robot.keyTap('a');
+      robot.keyToggle('shift', 'up');
+    }, 50);
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds an optional parameter for a second callback to be provided when registering a shortcut. This callback will be called when the registered shortcut has been released.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I'm currently implementing push-to-talk functionality in our app and needed a way to know when the shortcut has been released in order to mute the person's microphone again. This technically could've been solved in app, but it's both cleaner and beneficial to the community if it were implemented as part of the library :)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Works well in our app. I've added a test for the functionality as well, but currently it looks like the test suite is failing elsewhere.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
