### PR TITLE
Ability to unregister a shortcut via the shortcut's keys

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -164,9 +164,17 @@ You can unregister shortcut by using shortcutId returned by `registerShortcut()`
 ioHook.unregisterShortcut(id);
 ```
 
+### unregisterShortcutByKeys(keys)
+
+You can unregister shortcut by using the keys codes passed to `registerShortcut()`. Passing codes in the same order as during registration is not required.
+
+```js
+ioHook.unregisterShortcutByKeys(keys);
+```
+
 ### unregisterAllShortcuts()
 
-You can also unregister all shortcuts
+You can also unregister all shortcuts.
 ```js
 ioHook.unregisterAllShortcuts();
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,12 @@ declare class IOHook extends EventEmitter {
   unregisterShortcut(shortcutId: number): void
 
   /**
+   * Unregister shortcut via its key codes
+   * @param {Array<string|number>} keys
+   */
+  unregisterShortcut(keys: Array<string|number>): void
+
+  /**
    * Unregister all shortcuts
    */
   unregisterAllShortcuts(): void

--- a/index.js
+++ b/index.js
@@ -96,6 +96,47 @@ class IOHook extends EventEmitter {
   }
 
   /**
+   * Unregister shortcut via its key codes
+   * @param {string} keyCodes Keyboard keys matching the shortcut that should be unregistered
+   */
+  unregisterShortcutByKeys(keyCodes) {
+    // A traditional loop is used in order to access `this` from inside
+    for (let i = 0; i < this.shortcuts.length; i++) {
+      let shortcut = this.shortcuts[i];
+
+      // Convert any keycode numbers to strings
+      keyCodes.forEach((key, index) => {
+        if (typeof key !== 'string' && !(key instanceof String)) {
+          // Convert to string
+          keyCodes[index] = key.toString();
+        }
+      })
+
+      // Check if this is our shortcut
+      Object.keys(shortcut).every(key => {
+        if (key === 'callback' || key === 'id') return;
+
+        // Remove all given keys from keyCodes
+        // If any are not in this shortcut, then this shortcut does not match
+        // If at the end we have eliminated all codes in keyCodes, then we have succeeded
+        let index = keyCodes.indexOf(key);
+        if (index === -1) return false; // break
+
+        // Remove this key from the given keyCodes array
+        keyCodes.splice(index, 1);
+        return true;
+      });
+
+      // Is this the shortcut we want to remove?
+      if (keyCodes.length === 0) {
+        // Unregister this shortcut
+        this.shortcuts.splice(i, 1);
+        return;
+      }
+    }
+  }
+
+  /**
    * Unregister all shortcuts
    */
   unregisterAllShortcuts() {

--- a/test/specs/keyboard.spec.js
+++ b/test/specs/keyboard.spec.js
@@ -196,4 +196,27 @@ describe('Keyboard events', () => {
       robot.keyToggle('shift', 'up');
     }, 50);
   });
+
+  it('can unregister a shortcut via its keycodes', (done) => {
+    expect.assertions(0);
+
+    let shortcut = [42, 30];
+
+    // Register the shortcut
+    ioHook.registerShortcut(shortcut, (event) => {
+      // We're unregistering this shortcut. It should not have been called
+      expect.not.toHaveBeenCalled();
+    });
+
+    // Unregister the shortcut
+    ioHook.unregisterShortcutByKeys(shortcut);
+
+    ioHook.start();
+
+    setTimeout(() => { // Make sure ioHook starts before anything gets typed
+      robot.keyToggle('shift', 'down');
+      robot.keyTap('a');
+      robot.keyToggle('shift', 'up');
+    }, 50);
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds a new method for unregistering a shortcut via the key combination it's set to, rather than its ID if user do not or cannot keep track of the ID when registering the shortcut for whatever reason.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Continuing my Push-to-talk endeavors described in #118, our electron app works off a main thread and a helper thread. We try to keep the main thread light, and thus keeping track of IDs for shortcuts is not ideal. We could send the registered IDs back to the helper thread, but it already keeps track of a mapping from shortcut name -> key, and ideally that should be all the information that's necessary for iohook to identify a shortcut.

Additionally, this method is provided as a convenience if one does not want to build a system for tracking IDs of shortcuts they have created.

This system is also partially inspired by electron's [globalShortcut](https://electronjs.org/docs/api/global-shortcut) module, which also allows for unregistering a shortcut via the key codes it tracks.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in our app, but a test case is provided. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
