### PR TITLE
Add ability to specify tracking shortcuts via rawcodes instead of just keycodes

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -179,6 +179,22 @@ You can also unregister all shortcuts.
 ioHook.unregisterAllShortcuts();
 ```
 
+### useRawcode(using)
+
+Some libraries, such as [Mousetrap]() will emit keyboard events that contain
+a `rawcode` value. This is a separate, but equally valid, representation of
+the key that was pressed. However by default iohook instead uses an event's
+`keycode` field to determine which key was pressed. If these key codes do not
+line up, your shortcut will not be detected as pressed.
+
+To tell iohook to use the `rawcode` value instead, simply do so before
+starting iohook.
+
+```js
+iohook.useRawcode(true);
+iohook.start();
+```
+
 ### disableClickPropagation()
 
 You can disable mouse click event propagation. Click events are captured and emitted but not propagated to the window.

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,16 @@ declare class IOHook extends EventEmitter {
   setDebug(mode: boolean): void
 
   /**
+   * Specify that key event's `rawcode` property should be used instead of
+   * `keycode` when listening for key presses.
+   * 
+   * This allows iohook to be used in conjunction with other programs that may
+   * only provide a keycode.
+   * @param {Boolean} using 
+   */
+  useRawcode(using: boolean): void
+
+  /**
    * Enable mouse click propagation (enabled by default).
    * The click event are emitted and propagated.
    */

--- a/test/specs/keyboard.spec.js
+++ b/test/specs/keyboard.spec.js
@@ -219,4 +219,24 @@ describe('Keyboard events', () => {
       robot.keyToggle('shift', 'up');
     }, 50);
   });
+
+  it('can use rawcode instead of keycode when detecting events', (done) => {
+    expect.assertions(1);
+
+    let rawCodeShortcut = [65505, 65]; // Shift + A in rawcode
+
+    ioHook.registerShortcut(rawCodeShortcut, (event) => {
+      expect.toHaveBeenCalled();
+    });
+
+    // Check rawcode detection works
+    ioHook.useRawcode(true);
+    ioHook.start();
+
+    setTimeout(() => { // Make sure ioHook starts before anything gets typed
+      robot.keyToggle('shift', 'down');
+      robot.keyTap('a');
+      robot.keyToggle('shift', 'up');
+    }, 50);
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a method `iohook.useRawcode(bool)` that allows the user to specify whether shortcuts are in `rawcode` or `keycode` format.

## Motivation and Context

The distinction is in the two separate properties of a keyboard `event` that iohook receives when a key is pressed, `keycode` and `rawcode`. Depending on the application, a develop may want to use one over the other.

Fixes #121.

## How Has This Been Tested?

Associated documentation and a test that sets a shortcut using rawcode has been added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
