### PR TITLE
fix: add 'break' statement at the end of the case block

### DIFF
--- a/libuiohook/src/darwin/post_event.c
+++ b/libuiohook/src/darwin/post_event.c
@@ -35,7 +35,7 @@ static inline CGEventFlags get_key_event_mask(uiohook_event * const event) {
 
 	if (event->mask & (MASK_SHIFT))	{ native_mask |= kCGEventFlagMaskShift;		}
 	if (event->mask & (MASK_CTRL))	{ native_mask |= kCGEventFlagMaskControl;	}
-	if (event->mask & (MASK_META))	{ native_mask |= kCGEventFlagMaskControl;	}
+	if (event->mask & (MASK_META))	{ native_mask |= kCGEventFlagMaskCommand;	}
 	if (event->mask & (MASK_ALT))	{ native_mask |= kCGEventFlagMaskAlternate;	}
 	
 	if (event->type == EVENT_KEY_PRESSED || event->type == EVENT_KEY_RELEASED || event->type == EVENT_KEY_TYPED) {

--- a/libuiohook/src/demo_hook_async.c
+++ b/libuiohook/src/demo_hook_async.c
@@ -158,6 +158,7 @@ void dispatch_proc(uiohook_event * const event) {
 						break;
 				}
 			}
+			break;
 		case EVENT_KEY_RELEASED:
 			snprintf(buffer + length, sizeof(buffer) - length, 
 				",keycode=%u,rawcode=0x%X",


### PR DESCRIPTION
Missing 'break' statement at the end of the case block, causing fall-through to the next case.
